### PR TITLE
fix linking and update discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # lure-repo
 
-Documentation: https://gitea.arsenm.dev/Arsen6331/lure/src/branch/master/docs
+Documentation: https://gitea.elara.ws/Elara6331/lure/src/branch/master/docs
 
-Web interface: https://lure.arsenm.dev
+Web interface: https://lure.elara.ws

--- a/discord-bin/lure.sh
+++ b/discord-bin/lure.sh
@@ -1,5 +1,5 @@
 name='discord-bin'
-version='0.0.26'
+version='0.0.27'
 release='1'
 desc='Discord (popular voice + video app) using the system provided electron for increased security and performance'
 homepage='https://discord.com/'


### PR DESCRIPTION
Addresses https://github.com/Elara6331/lure-repo/issues/45 and https://github.com/Elara6331/lure-repo/issues/44 tested on fedora 38 discord starts with the update.
**Note:** If you want me to edit this into separate PRs/commits then I can